### PR TITLE
Drop HTTP cache TTL to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.1", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.3", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```

--- a/api-client/Gemfile.lock
+++ b/api-client/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 PATH
   remote: .
   specs:
-    get_into_teaching_api_client_faraday (0.1.2)
+    get_into_teaching_api_client_faraday (0.1.3)
       activesupport
       faraday
       faraday-encoding

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
@@ -1,7 +1,7 @@
 module Extensions
   module GetIntoTeachingApiClient
     module Caching
-      MAX_AGE = 10 * 60 # 10 minutes
+      MAX_AGE = 5 * 60 # 5 minutes
       MAX_RETRIES = 1
       RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
       RETRY_OPTIONS = {


### PR DESCRIPTION
We only want the cache to live for a maximum of 10 minutes; this is made up of a 5 minute TTL in the API and 5 minute TTL in this client-side HTTP cache.