### PR TITLE
Rename category to type for consistency

### DIFF
--- a/auto-generated-gem/docs/TeachingEventsApi.md
+++ b/auto-generated-gem/docs/TeachingEventsApi.md
@@ -264,7 +264,7 @@ opts = {
   type_id: 56, # Integer | 
   start_after: DateTime.parse('2013-10-20T19:20:30+01:00'), # DateTime | 
   start_before: DateTime.parse('2013-10-20T19:20:30+01:00'), # DateTime | 
-  quantity_per_category: 3 # Integer | Quantity to return (per type).
+  quantity_per_type: 3 # Integer | Quantity to return (per type).
 }
 
 begin
@@ -285,7 +285,7 @@ Name | Type | Description  | Notes
  **type_id** | **Integer**|  | [optional] 
  **start_after** | **DateTime**|  | [optional] 
  **start_before** | **DateTime**|  | [optional] 
- **quantity_per_category** | **Integer**| Quantity to return (per type). | [optional] [default to 3]
+ **quantity_per_type** | **Integer**| Quantity to return (per type). | [optional] [default to 3]
 
 ### Return type
 
@@ -324,7 +324,7 @@ end
 api_instance = GetIntoTeachingApiClient::TeachingEventsApi.new
 
 opts = { 
-  quantity_per_category: 3 # Integer | Quantity to return (per type).
+  quantity_per_type: 3 # Integer | Quantity to return (per type).
 }
 
 begin
@@ -340,7 +340,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **quantity_per_category** | **Integer**| Quantity to return (per type). | [optional] [default to 3]
+ **quantity_per_type** | **Integer**| Quantity to return (per type). | [optional] [default to 3]
 
 ### Return type
 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/api/teaching_events_api.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/api/teaching_events_api.rb
@@ -255,7 +255,7 @@ module GetIntoTeachingApiClient
     # @option opts [Integer] :type_id 
     # @option opts [DateTime] :start_after 
     # @option opts [DateTime] :start_before 
-    # @option opts [Integer] :quantity_per_category Quantity to return (per type). (default to 3)
+    # @option opts [Integer] :quantity_per_type Quantity to return (per type). (default to 3)
     # @return [Hash<String, Array<TeachingEvent>>]
     def search_teaching_events_indexed_by_type(opts = {})
       data, _status_code, _headers = search_teaching_events_indexed_by_type_with_http_info(opts)
@@ -270,7 +270,7 @@ module GetIntoTeachingApiClient
     # @option opts [Integer] :type_id 
     # @option opts [DateTime] :start_after 
     # @option opts [DateTime] :start_before 
-    # @option opts [Integer] :quantity_per_category Quantity to return (per type).
+    # @option opts [Integer] :quantity_per_type Quantity to return (per type).
     # @return [Array<(Hash<String, Array<TeachingEvent>>, Fixnum, Hash)>] Hash<String, Array<TeachingEvent>> data, response status code and response headers
     def search_teaching_events_indexed_by_type_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -290,7 +290,7 @@ module GetIntoTeachingApiClient
       query_params[:'TypeId'] = opts[:'type_id'] if !opts[:'type_id'].nil?
       query_params[:'StartAfter'] = opts[:'start_after'] if !opts[:'start_after'].nil?
       query_params[:'StartBefore'] = opts[:'start_before'] if !opts[:'start_before'].nil?
-      query_params[:'quantityPerCategory'] = opts[:'quantity_per_category'] if !opts[:'quantity_per_category'].nil?
+      query_params[:'quantityPerType'] = opts[:'quantity_per_type'] if !opts[:'quantity_per_type'].nil?
 
       # header parameters
       header_params = {}
@@ -318,7 +318,7 @@ module GetIntoTeachingApiClient
     # Retrieves upcoming teaching events grouped by type.
     # Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :quantity_per_category Quantity to return (per type). (default to 3)
+    # @option opts [Integer] :quantity_per_type Quantity to return (per type). (default to 3)
     # @return [Hash<String, Array<TeachingEvent>>]
     def upcoming_teaching_events_indexed_by_type(opts = {})
       data, _status_code, _headers = upcoming_teaching_events_indexed_by_type_with_http_info(opts)
@@ -328,7 +328,7 @@ module GetIntoTeachingApiClient
     # Retrieves upcoming teaching events grouped by type.
     # Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :quantity_per_category Quantity to return (per type).
+    # @option opts [Integer] :quantity_per_type Quantity to return (per type).
     # @return [Array<(Hash<String, Array<TeachingEvent>>, Fixnum, Hash)>] Hash<String, Array<TeachingEvent>> data, response status code and response headers
     def upcoming_teaching_events_indexed_by_type_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -339,7 +339,7 @@ module GetIntoTeachingApiClient
 
       # query parameters
       query_params = {}
-      query_params[:'quantityPerCategory'] = opts[:'quantity_per_category'] if !opts[:'quantity_per_category'].nil?
+      query_params[:'quantityPerType'] = opts[:'quantity_per_type'] if !opts[:'quantity_per_type'].nil?
 
       # header parameters
       header_params = {}

--- a/auto-generated-gem/spec/api/teaching_events_api_spec.rb
+++ b/auto-generated-gem/spec/api/teaching_events_api_spec.rb
@@ -93,7 +93,7 @@ describe 'TeachingEventsApi' do
   # @option opts [Integer] :type_id 
   # @option opts [DateTime] :start_after 
   # @option opts [DateTime] :start_before 
-  # @option opts [Integer] :quantity_per_category Quantity to return (per type).
+  # @option opts [Integer] :quantity_per_type Quantity to return (per type).
   # @return [Hash<String, Array<TeachingEvent>>]
   describe 'search_teaching_events_indexed_by_type test' do
     it 'should work' do
@@ -105,7 +105,7 @@ describe 'TeachingEventsApi' do
   # Retrieves upcoming teaching events grouped by type.
   # Retrieves upcoming teaching events grouped by type and limited to a given quantity per type.
   # @param [Hash] opts the optional parameters
-  # @option opts [Integer] :quantity_per_category Quantity to return (per type).
+  # @option opts [Integer] :quantity_per_type Quantity to return (per type).
   # @return [Hash<String, Array<TeachingEvent>>]
   describe 'upcoming_teaching_events_indexed_by_type test' do
     it 'should work' do


### PR DESCRIPTION
I didn't bump the version since this is a very small change and the old version hasn't been referenced anywhere yet.