### PR TITLE
Remove cache-control header override

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.6", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.7", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.6"
+    VERSION = "0.1.7"
   end
 end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
@@ -14,7 +14,6 @@ module Extensions
       def faraday
         Faraday.new do |f|
           f.use :http_cache, store: config.cache_store, shared_cache: false
-          f.use Faraday::OverrideCacheControl, cache_control: "private, max-age=#{MAX_AGE}"
           f.response :encoding
           f.adapter Faraday.default_adapter
           f.request :oauth2, config.api_key["Authorization"], token_type: :bearer
@@ -45,20 +44,6 @@ module Extensions
         end
 
         [data, response.status, response.headers]
-      end
-    end
-
-    class Faraday::OverrideCacheControl < Faraday::Middleware
-      def initialize(app, options = {})
-        super(app)
-        @cache_control = options[:cache_control]
-      end
-
-      def call(env)
-        response = @app.call(env)
-        cachable = response.headers["ETag"].present?
-        response.headers["Cache-Control"] = @cache_control if cachable
-        response
       end
     end
   end

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/caching_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/caching_spec.rb
@@ -26,30 +26,6 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::Caching do
     cache_store&.clear
   end
 
-  context "when caching is enabled" do
-    let(:cache_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-
-    it "does not override responses with a blanket Cache-Control header if no ETag was present" do
-      stub = stub_request(:get, get_endpoint)
-      .to_return(status: 200, body: data.to_json)
-
-      perform_get_request
-      perform_get_request
-
-      expect(stub).to have_been_requested.times(2)
-    end
-
-    it "overrides responses that have ETags with a blanket Cache-Control header" do
-      stub = stub_request(:get, get_endpoint)
-        .to_return(status: 200, body: data.to_json, headers: { ETag: "123" })
-
-      perform_get_request
-      perform_get_request
-
-      expect(stub).to have_been_requested.times(1)
-    end
-  end
-
   it "performs a POST request successfully" do
     stub_request(:post, post_endpoint)
       .with(body: { email: "test@test.com" })


### PR DESCRIPTION
> :warning: **Do not merge down until this has shipped: https://github.com/DFE-Digital/get-into-teaching-api/pull/392**

We were overriding the cache-control header to set a 5m private cache to any API responses deemed 'cacheable' (if they serve an ETag). This was done because it was not possible/straight forward at the time to set cache-control response headers in the API due to the requests being authenticated (and ASP.NET firmly preventing us).

This is no longer the case and we are implementing the cache-control headers in the API, so they can be removed from the API client.