### PR TITLE
Fix formatting of Date/Time objects during serialization

### DIFF
--- a/api-client/lib/api/client.rb
+++ b/api-client/lib/api/client.rb
@@ -8,10 +8,10 @@ require "get_into_teaching_api_client"
 
 require "api/client/version"
 require "api/extensions/get_into_teaching_api_client/configuration"
-require "api/extensions/get_into_teaching_api_client/caching"
+require "api/extensions/get_into_teaching_api_client/api_client"
 
 GetIntoTeachingApiClient::Configuration.prepend Extensions::GetIntoTeachingApiClient::Configuration
-GetIntoTeachingApiClient::ApiClient.prepend Extensions::GetIntoTeachingApiClient::Caching
+GetIntoTeachingApiClient::ApiClient.prepend Extensions::GetIntoTeachingApiClient::ApiClient
 
 module Api
   module Client

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -1,6 +1,6 @@
 module Extensions
   module GetIntoTeachingApiClient
-    module Caching
+    module ApiClient
       API_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %:z".freeze
       MAX_AGE = 5 * 60 # 5 minutes
       MAX_RETRIES = 1

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/caching.rb
@@ -1,6 +1,7 @@
 module Extensions
   module GetIntoTeachingApiClient
     module Caching
+      API_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %:z".freeze
       MAX_AGE = 5 * 60 # 5 minutes
       MAX_RETRIES = 1
       RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
@@ -44,6 +45,32 @@ module Extensions
         end
 
         [data, response.status, response.headers]
+      end
+
+      def build_request(http_method, path, opts = {})
+        opts[:query_params] = format_date_times(opts[:query_params])
+        
+        super(http_method, path, opts)
+      end
+  
+      def object_to_hash(obj)
+        if obj.respond_to?(:to_hash)
+          format_date_times(obj.to_hash)
+        else
+          obj
+        end
+      end
+
+    private
+
+      def format_date_times(params = {})
+        params.transform_values do |value|
+          if value.respond_to?(:strftime)
+            value.strftime(API_DATE_TIME_FORMAT) 
+          else
+            value
+          end
+        end
       end
     end
   end

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Extensions::GetIntoTeachingApiClient::Caching do
+RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
   let(:host) { "host.api" }
   let(:endpoint) { "endpoint" }
   let(:get_endpoint) { "https://#{host}/#{endpoint}/api/pick_list_items/candidate/channels" }

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/caching_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/caching_spec.rb
@@ -26,6 +26,68 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::Caching do
     cache_store&.clear
   end
 
+  describe "formatting DateTime/Time attributes in query string parameters" do
+    context "when UTC" do
+      it "formats with the offset +00:00" do
+        date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
+
+        stub_request(:get, "https://#{host}/#{endpoint}/api/teaching_events/search_indexed_by_type")
+          .with(query: { StartAfter: "2022-01-01 10:30:59 +00:00" })
+          .to_return(status: 200)
+          
+        expect do 
+          GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_indexed_by_type(start_after: date)
+        end.to_not raise_error
+      end
+    end
+
+    context "when not UTC" do
+      it "formats with the correct offset" do
+        date = Time.new(2022, 1, 1, 10, 30, 59, "-10:00")
+
+        stub_request(:get, "https://#{host}/#{endpoint}/api/teaching_events/search_indexed_by_type")
+          .with(query: { StartAfter: "2022-01-01 10:30:59 -10:00" })
+          .to_return(status: 200)
+          
+        expect do 
+          GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_indexed_by_type(start_after: date)
+        end.to_not raise_error
+      end
+    end
+  end
+
+  describe "formatting DateTime/Time attributes in request body" do
+    context "when UTC" do
+      it "formats with the offset +00:00" do
+        date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
+
+        stub_request(:post, "https://#{host}/#{endpoint}/api/teacher_training_adviser/candidates")
+          .with(body: { phoneCallScheduledAt: "2022-01-01 10:30:59 +00:00" })
+          .to_return(status: 200)
+          
+        expect do 
+          request = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(phoneCallScheduledAt: date)
+          GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new.sign_up_teacher_training_adviser_candidate(request)
+        end.to_not raise_error
+      end
+    end
+
+    context "when not UTC" do
+      it "formats with the correct offset" do
+        date = Time.new(2022, 1, 1, 10, 30, 59, "-10:00")
+
+        stub_request(:post, "https://#{host}/#{endpoint}/api/teacher_training_adviser/candidates")
+          .with(body: { phoneCallScheduledAt: "2022-01-01 10:30:59 -10:00" })
+          .to_return(status: 200)
+          
+        expect do 
+          request = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(phoneCallScheduledAt: date)
+          GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new.sign_up_teacher_training_adviser_candidate(request)
+        end.to_not raise_error
+      end
+    end
+  end
+
   it "performs a POST request successfully" do
     stub_request(:post, post_endpoint)
       .with(body: { email: "test@test.com" })


### PR DESCRIPTION
- Explicitly format Date/Time attributes in requests

Currently any `DateTime` or `Time` attributes are serialised to JSON by calling `to_s` which, in turn, calls `to_formatted_s(:default)`. The issue with this is that the default formatting behaves differently for `DateTime` or `Time` objects that have a `UTC` offset (as opposed to a `+00:00` offset). It results in `UTC` being present in the formatted date in place of the timezone offset, which isn't supported by the API.

This commit intercepts the serialisation process for both the JSON request body and the query string parameters, explicitly formatting them to ensure the offset is output in the `+/-HH:MM` format.

- Rename Caching extension to ApiClient

This extension used to primarily be about supporting caching, but it now does more including pre-processing some of the form data/query parameters to format them before sending them to the API. Renaming it to a more generic 'ApiClient' makes more sense and also aligns with the class it monkey patches.