### PR TITLE
Format Date correctly in request body/query string

### DIFF
--- a/api-client/Gemfile.lock
+++ b/api-client/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../auto-generated-gem
   specs:
-    get_into_teaching_api_client (1.1.9)
+    get_into_teaching_api_client (1.1.10)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 PATH
   remote: .
   specs:
-    get_into_teaching_api_client_faraday (0.1.12)
+    get_into_teaching_api_client_faraday (0.1.13)
       activesupport
       faraday
       faraday-encoding

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -1,7 +1,8 @@
 module Extensions
   module GetIntoTeachingApiClient
     module ApiClient
-      API_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %:z".freeze
+      API_DATE_FORMAT = "%Y-%m-%d".freeze
+      API_DATE_TIME_FORMAT = "#{API_DATE_FORMAT} %H:%M:%S %:z".freeze
       MAX_AGE = 5 * 60 # 5 minutes
       MAX_RETRIES = 1
       RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
@@ -65,10 +66,13 @@ module Extensions
 
       def format_date_times(params = {})
         params.transform_values do |value|
-          if value.respond_to?(:strftime)
-            value.strftime(API_DATE_TIME_FORMAT) 
-          else
-            value
+          case value
+            when DateTime, Time
+              value.strftime(API_DATE_TIME_FORMAT) 
+            when Date
+              value.strftime(API_DATE_FORMAT)
+            else
+              value
           end
         end
       end

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
     cache_store&.clear
   end
 
-  describe "formatting DateTime/Time attributes in query string parameters" do
+  describe "formatting DateTime/Time/Date attributes in query string parameters" do
     context "when UTC" do
       it "formats with the offset +00:00" do
         date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
@@ -54,9 +54,23 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         end.to_not raise_error
       end
     end
+
+    context "when Date" do
+      it "formats correctly" do
+        date = Date.new(2022, 1, 1)
+
+        stub_request(:get, "https://#{host}/#{endpoint}/api/teaching_events/search_grouped_by_type")
+          .with(query: { StartAfter: "2022-01-01" })
+          .to_return(status: 200)
+          
+        expect do 
+          GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_grouped_by_type(start_after: date)
+        end.to_not raise_error
+      end
+    end
   end
 
-  describe "formatting DateTime/Time attributes in request body" do
+  describe "formatting DateTime/Time/Date attributes in request body" do
     context "when UTC" do
       it "formats with the offset +00:00" do
         date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
@@ -83,6 +97,21 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         expect do 
           request = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(phoneCallScheduledAt: date)
           GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new.sign_up_teacher_training_adviser_candidate(request)
+        end.to_not raise_error
+      end
+    end
+
+    context "when Date" do
+      it "formats correctly" do
+        date = Date.new(2022, 1, 1)
+
+        stub_request(:post, "https://#{host}/#{endpoint}/api/candidates/access_tokens")
+          .with(body: { dateOfBirth: "2022-01-01" })
+          .to_return(status: 200)
+          
+        expect do 
+          request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(dateOfBirth: date)
+          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
         end.to_not raise_error
       end
     end


### PR DESCRIPTION
After updating the gem to include the latest API methods for some reason the `Date` types started formatting differently when calling `strftime` with a date/time format -- they changed from including only the date portion:

```
2000-01-24
```

To having the time added onto the end:

```
2000-01-24 00:00:00 +00:00
```

The API rejects this as a valid `Date` value. This commit updates the API client monkey patch to format `Date` objects explicitly.

I had also forgotten to run `bundle install` after updating the API client previously, so this includes the updated `Gemfile.lock`.