### PR TITLE
Update date/time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.12", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.14", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.13"
+    VERSION = "0.1.14"
   end
 end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -2,7 +2,7 @@ module Extensions
   module GetIntoTeachingApiClient
     module ApiClient
       API_DATE_FORMAT = "%Y-%m-%d".freeze
-      API_DATE_TIME_FORMAT = "#{API_DATE_FORMAT} %H:%M:%S %:z".freeze
+      API_DATE_TIME_FORMAT = "#{API_DATE_FORMAT}T%H:%M:%S%:z".freeze
       MAX_AGE = 5 * 60 # 5 minutes
       MAX_RETRIES = 1
       RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
 
         stub_request(:get, "https://#{host}/#{endpoint}/api/teaching_events/search_grouped_by_type")
-          .with(query: { StartAfter: "2022-01-01 10:30:59 +00:00" })
+          .with(query: { StartAfter: "2022-01-01T10:30:59+00:00" })
           .to_return(status: 200)
           
         expect do 
@@ -46,7 +46,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         date = Time.new(2022, 1, 1, 10, 30, 59, "-10:00")
 
         stub_request(:get, "https://#{host}/#{endpoint}/api/teaching_events/search_grouped_by_type")
-          .with(query: { StartAfter: "2022-01-01 10:30:59 -10:00" })
+          .with(query: { StartAfter: "2022-01-01T10:30:59-10:00" })
           .to_return(status: 200)
           
         expect do 
@@ -76,7 +76,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         date = DateTime.new(2022, 1, 1, 10, 30, 59).utc
 
         stub_request(:post, "https://#{host}/#{endpoint}/api/teacher_training_adviser/candidates")
-          .with(body: { phoneCallScheduledAt: "2022-01-01 10:30:59 +00:00" })
+          .with(body: { phoneCallScheduledAt: "2022-01-01T10:30:59+00:00" })
           .to_return(status: 200)
           
         expect do 
@@ -91,7 +91,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
         date = Time.new(2022, 1, 1, 10, 30, 59, "-10:00")
 
         stub_request(:post, "https://#{host}/#{endpoint}/api/teacher_training_adviser/candidates")
-          .with(body: { phoneCallScheduledAt: "2022-01-01 10:30:59 -10:00" })
+          .with(body: { phoneCallScheduledAt: "2022-01-01T10:30:59-10:00" })
           .to_return(status: 200)
           
         expect do 


### PR DESCRIPTION
I'm not sure why this has changed - the API used to be happy accepting `DateTime` values such as `2001-01-01 10:00:00 +05:00` but now it expects the format ISO 8601, so `2001-01-01T10:00:00+05:00`.

We're currently getting an error for any TTA sign ups that schedule a phone call due to this being the incorrect format.