### PR TITLE
Support request_id in Thread.current

### DIFF
--- a/api-client/Gemfile.lock
+++ b/api-client/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 PATH
   remote: .
   specs:
-    get_into_teaching_api_client_faraday (0.1.18)
+    get_into_teaching_api_client_faraday (0.1.19)
       activesupport
       faraday
       faraday-encoding

--- a/api-client/lib/api/client.rb
+++ b/api-client/lib/api/client.rb
@@ -4,10 +4,12 @@ require "faraday/http_cache"
 require "faraday/encoding"
 require "active_support/cache"
 require "active_support/notifications"
+require "active_support/current_attributes"
 require "get_into_teaching_api_client"
 require "faraday_middleware/circuit_breaker"
 
 require "api/client/version"
+require "api/models/current"
 require "api/extensions/get_into_teaching_api_client/configuration"
 require "api/extensions/get_into_teaching_api_client/api_client"
 

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.18"
+    VERSION = "0.1.19"
   end
 end

--- a/api-client/lib/api/models/current.rb
+++ b/api-client/lib/api/models/current.rb
@@ -1,0 +1,3 @@
+class GetIntoTeachingApiClient::Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -27,6 +27,34 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
     cache_store&.clear
   end
 
+  describe "request ids" do
+    let(:request_id) { "1234" }
+
+    context "when Current.request_id exists" do
+      before { GetIntoTeachingApiClient::Current.request_id = request_id }
+
+      it "sets the Request-Id header" do
+        stub_request(:get, "https://#{host}/#{endpoint}/api/pick_list_items/candidate/channels")
+          .with(headers: { "Request-Id": request_id })
+          .to_return(status: 200)
+
+        perform_get_request
+      end
+    end
+
+    context "when Current.request_id does not exist" do
+      before { GetIntoTeachingApiClient::Current.request_id = nil }
+
+      it "does not set a Request-Id header" do
+        stub_request(:get, "https://#{host}/#{endpoint}/api/pick_list_items/candidate/channels")
+          .with { |request| request.headers["Request-Id"].nil? }
+          .to_return(status: 200)
+
+        perform_get_request
+      end
+    end
+  end
+
   describe "formatting DateTime/Time/Date attributes in query string parameters" do
     context "when UTC" do
       it "formats with the offset +00:00" do
@@ -184,7 +212,6 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
     let(:timeout) { 5.minutes }
 
     context "when enabled" do
-
       before(:each) do
         Stoplight::Light.default_data_store = Stoplight::DataStore::Memory.new
 

--- a/api-client/spec/api/models/current_spec.rb
+++ b/api-client/spec/api/models/current_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe GetIntoTeachingApiClient::Current do
+  context "attributes" do
+    it { is_expected.to respond_to :request_id }
+  end
+end


### PR DESCRIPTION
We want to be able to track requests from the app right through to the API. In order to do this we need to set a correlation id in the request headers going to the API. Rails has a request id we can tap into, but getting it into the API client for all requests will be difficult/verbose.

To make life easier this commit updates the API client to expect a request id set on the current thread. We are using
`ActiveSupport::CurrentAttributes` to ensure the thread globals get cleaned up after each request (in Rails).

If a `request_id` is present it will be written to the `Request-Id` header prior to making the API request (ASP.NET Core will pick up on this and use it as the `TraceId`).

We should be able to write to this from our `ApplicationController` in a `before_action` such as:

```
def set_request_id
  GetIntoTeachingApiClient::Current.request_id = request.uuid
end
```