### PR TITLE
Invalidate cache

### DIFF
--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -1,4 +1,4 @@
-require_relative "./invalidate_cache"
+require_relative "./cache_invalidator"
 
 module Extensions
   module GetIntoTeachingApiClient
@@ -26,8 +26,8 @@ module Extensions
           end
           f.use Faraday::Response::RaiseError
           f.use RequestId
-          f.use InvalidateCache, store: config.cache_store
           f.use :http_cache, store: config.cache_store, shared_cache: false
+          f.request :invalidate_cache, store: config.cache_store
           f.request :oauth2, config.api_key["Authorization"], token_type: :bearer
           f.request :retry, RETRY_OPTIONS
           f.response :encoding
@@ -76,7 +76,7 @@ module Extensions
         end
       end
 
-    private
+      private
 
       def format_date_times(params = {})
         params.transform_values do |value|

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -1,3 +1,5 @@
+require_relative "./invalidate_cache"
+
 module Extensions
   module GetIntoTeachingApiClient
     module ApiClient
@@ -19,11 +21,12 @@ module Extensions
             f.use :circuit_breaker,
                   threshold: config.circuit_breaker[:threshold],
                   timeout: config.circuit_breaker[:timeout],
-                  fallback: -> (_, exception) { raise_circuit_broken_error(exception) },
-                  error_handler: -> (exception, handler) { handle_error(exception, handler) }
+                  fallback: ->(_, exception) { raise_circuit_broken_error(exception) },
+                  error_handler: ->(exception, handler) { handle_error(exception, handler) }
           end
           f.use Faraday::Response::RaiseError
           f.use RequestId
+          f.use InvalidateCache, store: config.cache_store
           f.use :http_cache, store: config.cache_store, shared_cache: false
           f.request :oauth2, config.api_key["Authorization"], token_type: :bearer
           f.request :retry, RETRY_OPTIONS
@@ -47,7 +50,6 @@ module Extensions
         end
 
         [data, response.status, response.headers]
-
       rescue Faraday::Error => error
         if error.response.present?
           raise ::GetIntoTeachingApiClient::ApiError.new(
@@ -104,6 +106,7 @@ module Extensions
       # to remain unchanged.
       def raise_circuit_broken_error(exception)
         raise exception if exception.present?
+
         raise ::GetIntoTeachingApiClient::CircuitBrokenError
       end
 
@@ -111,15 +114,14 @@ module Extensions
         def initialize(app)
           super(app)
         end
-  
+
         def call(env)
           request_id = ::GetIntoTeachingApiClient::Current.request_id
-          
+
           env[:request_headers]["Request-Id"] = request_id if request_id
-          
+
           @app.call(env)
         end
-  
       end
     end
   end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -76,7 +76,7 @@ module Extensions
         end
       end
 
-      private
+    private
 
       def format_date_times(params = {})
         params.transform_values do |value|

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/cache_invalidator.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/cache_invalidator.rb
@@ -1,6 +1,6 @@
-class InvalidateCache < Faraday::Middleware
+class CacheInvalidator < Faraday::Middleware
   CACHE_INVALIDATION_PATHS = [
-    /api\/teaching_events/
+    %r{api/teaching_events}
   ].freeze
 
   def initialize(app, store: nil)
@@ -9,12 +9,12 @@ class InvalidateCache < Faraday::Middleware
     @store = store
   end
 
-  def call(env)
+  def on_request(env)
     path_invalidates_cache = CACHE_INVALIDATION_PATHS.any? { |p| p.match?(env.url.path) }
     method_invalidates_cache = %i[post put].include?(env.method)
-    if method_invalidates_cache && path_invalidates_cache
-      @store.clear if @store
-    end
-    @app.call(env)
+
+    @store&.clear if method_invalidates_cache && path_invalidates_cache
   end
 end
+
+Faraday::Request.register_middleware invalidate_cache: -> { CacheInvalidator }

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/invalidate_cache.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/invalidate_cache.rb
@@ -1,0 +1,22 @@
+require "yaml"
+
+class InvalidateCache < Faraday::Middleware
+  CACHE_INVALIDATION_PATHS = [
+    /api\/teaching_events/
+  ].freeze
+
+  def initialize(app, store: nil)
+    super(app)
+
+    @store = store
+  end
+
+  def call(env)
+    path_invalidates_cache = CACHE_INVALIDATION_PATHS.any? { |p| p.match?(env.url.path) }
+    method_invalidates_cache = %i[post put].include?(env.method)
+    if method_invalidates_cache && path_invalidates_cache
+      @store.clear if @store
+    end
+    @app.call(env)
+  end
+end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/invalidate_cache.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/invalidate_cache.rb
@@ -1,5 +1,3 @@
-require "yaml"
-
 class InvalidateCache < Faraday::Middleware
   CACHE_INVALIDATION_PATHS = [
     /api\/teaching_events/

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -294,22 +294,36 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
   end
 
   describe "Invalidate cache" do
+    let(:headers)  { { "Cache-Control" => "max-age=300; private" } }
+
     it "cache is retained when cache is not invalidated" do
       stub_request(:get, get_endpoint)
-        .to_return(status: 200, body: [{ value: "first response" }].to_json)
-
+        .to_return(
+          status: 200, 
+          body: [{ value: "first response" }].to_json, 
+          headers: headers
+        )
+      
       expect(perform_get_request.first).to have_attributes({ value: "first response" })
 
       stub_request(:get, get_endpoint)
-        .to_return(status: 200, body: [{ value: "second response" }].to_json)
+        .to_return(
+          status: 200, 
+          body: [{ value: "second response" }].to_json, 
+          headers: headers
+        )
 
       expect(perform_get_request.first).to have_attributes({ value: "first response" })
     end
 
     it "cache is cleared when posting to a 'teaching event' path" do
       stub_request(:get, get_endpoint)
-        .to_return(status: 200, body: [{ value: "first response" }].to_json)
-
+        .to_return(
+          status: 200, 
+          body: [{ value: "first response" }].to_json, 
+          headers: headers
+        )
+      
       expect(perform_get_request.first).to have_attributes({ value: "first response" })
 
       stub_request(:post, "https://#{host}/#{endpoint}/api/teaching_events")
@@ -318,7 +332,11 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
       GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event({})
 
       stub_request(:get, get_endpoint)
-        .to_return(status: 200, body: [{ value: "second response" }].to_json)
+        .to_return(
+          status: 200, 
+          body: [{ value: "second response" }].to_json, 
+          headers: headers
+        )
 
       expect(perform_get_request.first).to have_attributes({ value: "second response" })
     end

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -294,22 +294,22 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
   end
 
   describe "Invalidate cache" do
-    let(:headers)  { { "Cache-Control" => "max-age=300; private" } }
+    let(:headers) { { "Cache-Control" => "max-age=300; private" } }
 
     it "cache is retained when cache is not invalidated" do
       stub_request(:get, get_endpoint)
         .to_return(
-          status: 200, 
-          body: [{ value: "first response" }].to_json, 
+          status: 200,
+          body: [{ value: "first response" }].to_json,
           headers: headers
         )
-      
+
       expect(perform_get_request.first).to have_attributes({ value: "first response" })
 
       stub_request(:get, get_endpoint)
         .to_return(
-          status: 200, 
-          body: [{ value: "second response" }].to_json, 
+          status: 200,
+          body: [{ value: "second response" }].to_json,
           headers: headers
         )
 
@@ -319,11 +319,11 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
     it "cache is cleared when posting to a 'teaching event' path" do
       stub_request(:get, get_endpoint)
         .to_return(
-          status: 200, 
-          body: [{ value: "first response" }].to_json, 
+          status: 200,
+          body: [{ value: "first response" }].to_json,
           headers: headers
         )
-      
+
       expect(perform_get_request.first).to have_attributes({ value: "first response" })
 
       stub_request(:post, "https://#{host}/#{endpoint}/api/teaching_events")
@@ -333,8 +333,8 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
 
       stub_request(:get, get_endpoint)
         .to_return(
-          status: 200, 
-          body: [{ value: "second response" }].to_json, 
+          status: 200,
+          body: [{ value: "second response" }].to_json,
           headers: headers
         )
 

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
   let(:post_endpoint) { "https://#{host}/#{endpoint}/api/candidates/access_tokens" }
   let(:token) { "test" }
   let(:data) { [{ id: 123, value: "test" }] }
-  let(:cache_store) { ActiveSupport::Cache.lookup_store(:null_store) }
+  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
 
   def perform_get_request
     GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_channels
@@ -23,6 +23,7 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
       config.base_path = endpoint
       config.api_key["Authorization"] = token
       config.cache_store = cache_store
+      config.circuit_breaker = { enabled: false }
     end
     cache_store&.clear
   end
@@ -289,6 +290,37 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
           expect { perform_get_request }.to raise_error(GetIntoTeachingApiClient::CircuitBrokenError)
         end
       end
+    end
+  end
+
+  describe "Invalidate cache" do
+    it "cache is retained when cache is not invalidated" do
+      stub_request(:get, get_endpoint)
+        .to_return(status: 200, body: [{ value: "first response" }].to_json)
+
+      expect(perform_get_request.first).to have_attributes({ value: "first response" })
+
+      stub_request(:get, get_endpoint)
+        .to_return(status: 200, body: [{ value: "second response" }].to_json)
+
+      expect(perform_get_request.first).to have_attributes({ value: "first response" })
+    end
+
+    it "cache is cleared when posting to a 'teaching event' path" do
+      stub_request(:get, get_endpoint)
+        .to_return(status: 200, body: [{ value: "first response" }].to_json)
+
+      expect(perform_get_request.first).to have_attributes({ value: "first response" })
+
+      stub_request(:post, "https://#{host}/#{endpoint}/api/teaching_events")
+        .to_return(status: 201)
+
+      GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event({})
+
+      stub_request(:get, get_endpoint)
+        .to_return(status: 200, body: [{ value: "second response" }].to_json)
+
+      expect(perform_get_request.first).to have_attributes({ value: "second response" })
     end
   end
 end


### PR DESCRIPTION
Currently, when a teaching event is posted to the API, it will not be immediately available on the hosted environments because of HTTP caching. 

The InvalidateCache middleware checks whether a request is posted to a teaching_event path, and if true, clears the cache.