### PR TITLE
Bump version for cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.27", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.28", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```ruby

--- a/api-client/Gemfile.lock
+++ b/api-client/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../auto-generated-gem
   specs:
-    get_into_teaching_api_client (1.1.13)
+    get_into_teaching_api_client (1.1.14)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
@@ -9,7 +9,7 @@ PATH
 PATH
   remote: .
   specs:
-    get_into_teaching_api_client_faraday (0.1.19)
+    get_into_teaching_api_client_faraday (0.1.28)
       activesupport
       faraday
       faraday-encoding
@@ -50,7 +50,7 @@ GEM
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)
       stoplight (~> 2.1)
-    ffi (1.14.2)
+    ffi (1.15.0)
     hashdiff (1.0.1)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.27"
+    VERSION = "0.1.28"
   end
 end

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -27,7 +27,7 @@ module Extensions
           f.use Faraday::Response::RaiseError
           f.use RequestId
           f.use :http_cache, store: config.cache_store, shared_cache: false
-          f.request :invalidate_cache, store: config.cache_store
+          f.request :invalidate_cache, store: config.cache_store, base_path: config.base_path
           f.request :oauth2, config.api_key["Authorization"], token_type: :bearer
           f.request :retry, RETRY_OPTIONS
           f.response :encoding


### PR DESCRIPTION
- Bump version

- Make cache invalidation more extensible

Swap the regex of paths for an array of path prefixes and update the tests to be more dynamic, so we don't need to change them when adding additional paths that invalidate the cache.

Update middleware to work correctly when `base_path` is set (we don't use this at the moment, but it will potentially avoid issues in the future).

Minor housekeeping of the api client specs in general.