### PR TITLE
Remove the need for a `body` key when upserting a teaching event

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.31", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.32", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```ruby

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.31"
+    VERSION = "0.1.32"
   end
 end

--- a/auto-generated-gem/docs/TeachingEventsApi.md
+++ b/auto-generated-gem/docs/TeachingEventsApi.md
@@ -241,7 +241,7 @@ Name | Type | Description  | Notes
 
 
 # **upsert_teaching_event**
-> TeachingEvent upsert_teaching_event(opts)
+> TeachingEvent upsert_teaching_event(body)
 
 Adds or updates a teaching event.
 
@@ -261,13 +261,12 @@ end
 
 api_instance = GetIntoTeachingApiClient::TeachingEventsApi.new
 
-opts = { 
-  body: GetIntoTeachingApiClient::TeachingEvent.new # TeachingEvent | 
-}
+body = GetIntoTeachingApiClient::TeachingEvent.new # TeachingEvent | Teaching event to upsert.
+
 
 begin
   #Adds or updates a teaching event.
-  result = api_instance.upsert_teaching_event(opts)
+  result = api_instance.upsert_teaching_event(body)
   p result
 rescue GetIntoTeachingApiClient::ApiError => e
   puts "Exception when calling TeachingEventsApi->upsert_teaching_event: #{e}"
@@ -278,7 +277,7 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**TeachingEvent**](TeachingEvent.md)|  | [optional] 
+ **body** | [**TeachingEvent**](TeachingEvent.md)| Teaching event to upsert. | 
 
 ### Return type
 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/api/teaching_events_api.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/api/teaching_events_api.rb
@@ -255,22 +255,26 @@ module GetIntoTeachingApiClient
     end
     # Adds or updates a teaching event.
     # If the `id` is specified then the existing teaching event will be updated, otherwise a new teaching event will be created.
+    # @param body Teaching event to upsert.
     # @param [Hash] opts the optional parameters
-    # @option opts [TeachingEvent] :body 
     # @return [TeachingEvent]
-    def upsert_teaching_event(opts = {})
-      data, _status_code, _headers = upsert_teaching_event_with_http_info(opts)
+    def upsert_teaching_event(body, opts = {})
+      data, _status_code, _headers = upsert_teaching_event_with_http_info(body, opts)
       data
     end
 
     # Adds or updates a teaching event.
     # If the &#x60;id&#x60; is specified then the existing teaching event will be updated, otherwise a new teaching event will be created.
+    # @param body Teaching event to upsert.
     # @param [Hash] opts the optional parameters
-    # @option opts [TeachingEvent] :body 
     # @return [Array<(TeachingEvent, Fixnum, Hash)>] TeachingEvent data, response status code and response headers
-    def upsert_teaching_event_with_http_info(opts = {})
+    def upsert_teaching_event_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: TeachingEventsApi.upsert_teaching_event ...'
+      end
+      # verify the required parameter 'body' is set
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling TeachingEventsApi.upsert_teaching_event"
       end
       # resource path
       local_var_path = '/api/teaching_events'
@@ -289,7 +293,7 @@ module GetIntoTeachingApiClient
       form_params = {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
+      post_body = @api_client.object_to_http_body(body)
       auth_names = ['apiKey']
       data, status_code, headers = @api_client.call_api(:POST, local_var_path,
         :header_params => header_params,

--- a/auto-generated-gem/spec/api/teaching_events_api_spec.rb
+++ b/auto-generated-gem/spec/api/teaching_events_api_spec.rb
@@ -89,8 +89,8 @@ describe 'TeachingEventsApi' do
   # unit tests for upsert_teaching_event
   # Adds or updates a teaching event.
   # If the &#x60;id&#x60; is specified then the existing teaching event will be updated, otherwise a new teaching event will be created.
+  # @param body Teaching event to upsert.
   # @param [Hash] opts the optional parameters
-  # @option opts [TeachingEvent] :body 
   # @return [TeachingEvent]
   describe 'upsert_teaching_event test' do
     it 'should work' do


### PR DESCRIPTION
When SwaggerGen is generating the client library, it is expecting a teaching event to be in a hash with a `body` key for upsert_teaching_event.

SwaggerRequestBody annotation has been added to the API action to match the other post actions, which seems to have fixed this.