### PR TITLE
Update validation for classroom experience note

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.32", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.33", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```ruby

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.32"
+    VERSION = "0.1.33"
   end
 end

--- a/auto-generated-gem/lib/get_into_teaching_api_client/models/classroom_experience_note.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/models/classroom_experience_note.rb
@@ -91,10 +91,6 @@ module GetIntoTeachingApiClient
         invalid_properties.push('invalid value for "action", the character length must be great than or equal to 1.')
       end
 
-      if @action !~ Regexp.new(/\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z/)
-        invalid_properties.push('invalid value for "action", must conform to the pattern /\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z/.')
-      end
-
       if @date.nil?
         invalid_properties.push('invalid value for "date", date cannot be nil.')
       end
@@ -128,7 +124,6 @@ module GetIntoTeachingApiClient
       return false if @recorded_at.nil?
       return false if @action.nil?
       return false if @action.to_s.length < 1
-      return false if @action !~ Regexp.new(/\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z/)
       return false if @date.nil?
       return false if @school_urn.nil?
       return false if @school_urn.to_s.length > 6
@@ -147,10 +142,6 @@ module GetIntoTeachingApiClient
 
       if action.to_s.length < 1
         fail ArgumentError, 'invalid value for "action", the character length must be great than or equal to 1.'
-      end
-
-      if action !~ Regexp.new(/\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z/)
-        fail ArgumentError, 'invalid value for "action", must conform to the pattern /\\A(REQUEST|ACCEPTED|ATTENDED|DID NOT ATTEND|CANCELLED BY (SCHOOL|CANDIDATE))\\z/.'
       end
 
       @action = action


### PR DESCRIPTION
Previously it generated a regex that didn't work property; so its been swapped out to check an array of explicit values instead in the API and client-side validation support is removed.