### PR TITLE
Add adviser_status_id to TeacherTrainingAdviserSignUp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.41", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.42", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```ruby

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.41"
+    VERSION = "0.1.42"
   end
 end

--- a/auto-generated-gem/docs/TeacherTrainingAdviserSignUp.md
+++ b/auto-generated-gem/docs/TeacherTrainingAdviserSignUp.md
@@ -20,6 +20,7 @@ Name | Type | Description | Notes
 **has_gcse_science_id** | **Integer** |  | [optional] 
 **planning_to_retake_gcse_maths_and_english_id** | **Integer** |  | [optional] 
 **planning_to_retake_gcse_science_id** | **Integer** |  | [optional] 
+**adviser_status_id** | **Integer** |  | [optional] 
 **email** | **String** |  | 
 **first_name** | **String** |  | 
 **last_name** | **String** |  | 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/models/teacher_training_adviser_sign_up.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/models/teacher_training_adviser_sign_up.rb
@@ -48,6 +48,8 @@ module GetIntoTeachingApiClient
 
     attr_accessor :planning_to_retake_gcse_science_id
 
+    attr_accessor :adviser_status_id
+
     attr_accessor :email
 
     attr_accessor :first_name
@@ -96,6 +98,7 @@ module GetIntoTeachingApiClient
         :'has_gcse_science_id' => :'hasGcseScienceId',
         :'planning_to_retake_gcse_maths_and_english_id' => :'planningToRetakeGcseMathsAndEnglishId',
         :'planning_to_retake_gcse_science_id' => :'planningToRetakeGcseScienceId',
+        :'adviser_status_id' => :'adviserStatusId',
         :'email' => :'email',
         :'first_name' => :'firstName',
         :'last_name' => :'lastName',
@@ -133,6 +136,7 @@ module GetIntoTeachingApiClient
         :'has_gcse_science_id' => :'Integer',
         :'planning_to_retake_gcse_maths_and_english_id' => :'Integer',
         :'planning_to_retake_gcse_science_id' => :'Integer',
+        :'adviser_status_id' => :'Integer',
         :'email' => :'String',
         :'first_name' => :'String',
         :'last_name' => :'String',
@@ -224,6 +228,10 @@ module GetIntoTeachingApiClient
 
       if attributes.has_key?(:'planningToRetakeGcseScienceId')
         self.planning_to_retake_gcse_science_id = attributes[:'planningToRetakeGcseScienceId']
+      end
+
+      if attributes.has_key?(:'adviserStatusId')
+        self.adviser_status_id = attributes[:'adviserStatusId']
       end
 
       if attributes.has_key?(:'email')
@@ -353,6 +361,7 @@ module GetIntoTeachingApiClient
           has_gcse_science_id == o.has_gcse_science_id &&
           planning_to_retake_gcse_maths_and_english_id == o.planning_to_retake_gcse_maths_and_english_id &&
           planning_to_retake_gcse_science_id == o.planning_to_retake_gcse_science_id &&
+          adviser_status_id == o.adviser_status_id &&
           email == o.email &&
           first_name == o.first_name &&
           last_name == o.last_name &&
@@ -378,7 +387,7 @@ module GetIntoTeachingApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [candidate_id, qualification_id, subject_taught_id, past_teaching_position_id, preferred_teaching_subject_id, country_id, accepted_policy_id, type_id, uk_degree_grade_id, degree_status_id, degree_type_id, initial_teacher_training_year_id, preferred_education_phase_id, has_gcse_maths_and_english_id, has_gcse_science_id, planning_to_retake_gcse_maths_and_english_id, planning_to_retake_gcse_science_id, email, first_name, last_name, date_of_birth, teacher_id, degree_subject, address_telephone, address_line1, address_line2, address_city, address_postcode, phone_call_scheduled_at, already_subscribed_to_teacher_training_adviser, can_subscribe_to_teacher_training_adviser].hash
+      [candidate_id, qualification_id, subject_taught_id, past_teaching_position_id, preferred_teaching_subject_id, country_id, accepted_policy_id, type_id, uk_degree_grade_id, degree_status_id, degree_type_id, initial_teacher_training_year_id, preferred_education_phase_id, has_gcse_maths_and_english_id, has_gcse_science_id, planning_to_retake_gcse_maths_and_english_id, planning_to_retake_gcse_science_id, adviser_status_id, email, first_name, last_name, date_of_birth, teacher_id, degree_subject, address_telephone, address_line1, address_line2, address_city, address_postcode, phone_call_scheduled_at, already_subscribed_to_teacher_training_adviser, can_subscribe_to_teacher_training_adviser].hash
     end
 
     # Builds the object from hash

--- a/auto-generated-gem/spec/models/teacher_training_adviser_sign_up_spec.rb
+++ b/auto-generated-gem/spec/models/teacher_training_adviser_sign_up_spec.rb
@@ -134,6 +134,12 @@ describe 'TeacherTrainingAdviserSignUp' do
     end
   end
 
+  describe 'test attribute "adviser_status_id"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "email"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
We require the `adviser_status_id` to be able to identify candidates in a 'closed' state. The API will return this as part of the response for exchanging an access token and expects the app to post the value back.