### PR TITLE
Add reference attribute to existing candidate request

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-gem "get_into_teaching_api_client_faraday", "0.1.47", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
+gem "get_into_teaching_api_client_faraday", "0.1.48", git: "git@github.com:DFE-Digital/get-into-teaching-api-ruby-client.git", require: "api/client"
 ```
 
 ```ruby

--- a/api-client/lib/api/client/version.rb
+++ b/api-client/lib/api/client/version.rb
@@ -1,5 +1,5 @@
 module Api
   module Client
-    VERSION = "0.1.47"
+    VERSION = "0.1.48"
   end
 end

--- a/auto-generated-gem/docs/ExistingCandidateRequest.md
+++ b/auto-generated-gem/docs/ExistingCandidateRequest.md
@@ -7,5 +7,6 @@ Name | Type | Description | Notes
 **last_name** | **String** |  | [optional] 
 **email** | **String** |  | 
 **date_of_birth** | **DateTime** |  | [optional] 
+**reference** | **String** |  | [optional] 
 
 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/models/existing_candidate_request.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/models/existing_candidate_request.rb
@@ -22,13 +22,16 @@ module GetIntoTeachingApiClient
 
     attr_accessor :date_of_birth
 
+    attr_accessor :reference
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'first_name' => :'firstName',
         :'last_name' => :'lastName',
         :'email' => :'email',
-        :'date_of_birth' => :'dateOfBirth'
+        :'date_of_birth' => :'dateOfBirth',
+        :'reference' => :'reference'
       }
     end
 
@@ -38,7 +41,8 @@ module GetIntoTeachingApiClient
         :'first_name' => :'String',
         :'last_name' => :'String',
         :'email' => :'String',
-        :'date_of_birth' => :'DateTime'
+        :'date_of_birth' => :'DateTime',
+        :'reference' => :'String'
       }
     end
 
@@ -64,6 +68,10 @@ module GetIntoTeachingApiClient
 
       if attributes.has_key?(:'dateOfBirth')
         self.date_of_birth = attributes[:'dateOfBirth']
+      end
+
+      if attributes.has_key?(:'reference')
+        self.reference = attributes[:'reference']
       end
     end
 
@@ -151,7 +159,8 @@ module GetIntoTeachingApiClient
           first_name == o.first_name &&
           last_name == o.last_name &&
           email == o.email &&
-          date_of_birth == o.date_of_birth
+          date_of_birth == o.date_of_birth &&
+          reference == o.reference
     end
 
     # @see the `==` method
@@ -163,7 +172,7 @@ module GetIntoTeachingApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [first_name, last_name, email, date_of_birth].hash
+      [first_name, last_name, email, date_of_birth, reference].hash
     end
 
     # Builds the object from hash

--- a/auto-generated-gem/spec/models/existing_candidate_request_spec.rb
+++ b/auto-generated-gem/spec/models/existing_candidate_request_spec.rb
@@ -56,4 +56,10 @@ describe 'ExistingCandidateRequest' do
     end
   end
 
+  describe 'test attribute "reference"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end


### PR DESCRIPTION
We can now optionally add a reference to requests that send an ExistingCandidateRequest. This lets the API tag metrics at
a more granular level.