### PR TITLE
Correct formatting of array query parameters

### DIFF
--- a/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/api_client.rb
@@ -21,7 +21,7 @@ module Extensions
       end
 
       def build_request(http_method, path, request, opts = {})
-        opts[:query_params] = format_date_times(opts[:query_params])
+        opts[:query_params] = format_query_params(opts[:query_params])
 
         super(http_method, path, request, opts)
       end
@@ -35,6 +35,13 @@ module Extensions
       end
 
       private
+
+      def format_query_params(params = {})
+        params = format_date_times(params)
+        params.transform_values do |value|
+          value.is_a?(Array) ? value.join(",") : value
+        end
+      end
 
       def format_date_times(params = {})
         params.transform_values do |value|

--- a/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
+++ b/api-client/spec/api/extensions/get_into_teaching_api_client/api_client_spec.rb
@@ -175,6 +175,15 @@ RSpec.describe Extensions::GetIntoTeachingApiClient::ApiClient do
     expect { perform_get_request }.to raise_error(GetIntoTeachingApiClient::ApiError)
   end
 
+  it "performs a GET request with multiple query parameters successfully" do
+    stub_request(:get, "#{base_url}/api/schools_experience/candidates")
+      .with(query: { ids: "first,second" })
+      .to_return(status: 200, body: data.to_json)
+
+    ids = %w(first second)
+    GetIntoTeachingApiClient::SchoolsExperienceApi.new.get_schools_experience_sign_ups(ids)
+  end
+
   it "sets an Authorization header on the request" do
     stub_request(:get, get_endpoint)
       .with(headers: { "Authorization" => "Bearer #{token}" })


### PR DESCRIPTION
The API is configured to accept query parameters in the format that the old API client version used (which was based of how Typhoeus did it by default):

```
param=value1,value2
```

Faraday can be configured to use either:

```
param[]=value1,param[]=value2
```

Or:

```
param=value1,param=value2
```

We can probably update the API to support one of the methods Faraday uses (as they are both pretty standard now), but as this needs to be backwards compatible I'm updating the API client to work how it previously did (updating the API to work for multiple scenarios is not straight forward).

I haven't bumped the version as nothing has been shipped with it yet.