### PR TITLE
Fix return type of matchback endpoint

### DIFF
--- a/auto-generated-gem/docs/TeacherTrainingAdviserApi.md
+++ b/auto-generated-gem/docs/TeacherTrainingAdviserApi.md
@@ -84,7 +84,7 @@ end
 
 ## matchback_candidate
 
-> matchback_candidate(existing_candidate_request)
+> <TeacherTrainingAdviserSignUp> matchback_candidate(existing_candidate_request)
 
 Perform a matchback operation to retrieve a pre-populated TeacherTrainingAdviserSignUp for the candidate.
 
@@ -108,7 +108,8 @@ existing_candidate_request = GetIntoTeachingApiClient::ExistingCandidateRequest.
 
 begin
   # Perform a matchback operation to retrieve a pre-populated TeacherTrainingAdviserSignUp for the candidate.
-  api_instance.matchback_candidate(existing_candidate_request)
+  result = api_instance.matchback_candidate(existing_candidate_request)
+  p result
 rescue GetIntoTeachingApiClient::ApiError => e
   puts "Error when calling TeacherTrainingAdviserApi->matchback_candidate: #{e}"
 end
@@ -116,9 +117,9 @@ end
 
 #### Using the matchback_candidate_with_http_info variant
 
-This returns an Array which contains the response data (`nil` in this case), status code and headers.
+This returns an Array which contains the response data, status code and headers.
 
-> <Array(nil, Integer, Hash)> matchback_candidate_with_http_info(existing_candidate_request)
+> <Array(<TeacherTrainingAdviserSignUp>, Integer, Hash)> matchback_candidate_with_http_info(existing_candidate_request)
 
 ```ruby
 begin
@@ -126,7 +127,7 @@ begin
   data, status_code, headers = api_instance.matchback_candidate_with_http_info(existing_candidate_request)
   p status_code # => 2xx
   p headers # => { ... }
-  p data # => nil
+  p data # => <TeacherTrainingAdviserSignUp>
 rescue GetIntoTeachingApiClient::ApiError => e
   puts "Error when calling TeacherTrainingAdviserApi->matchback_candidate_with_http_info: #{e}"
 end
@@ -140,7 +141,7 @@ end
 
 ### Return type
 
-nil (empty response body)
+[**TeacherTrainingAdviserSignUp**](TeacherTrainingAdviserSignUp.md)
 
 ### Authorization
 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/api/teacher_training_adviser_api.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/api/teacher_training_adviser_api.rb
@@ -97,17 +97,17 @@ module GetIntoTeachingApiClient
     # Attempts to matchback against a known candidate and returns a pre-populated TeacherTrainingAdviser sign up if a match is found.
     # @param existing_candidate_request [ExistingCandidateRequest] Candidate details to matchback.
     # @param [Hash] opts the optional parameters
-    # @return [nil]
+    # @return [TeacherTrainingAdviserSignUp]
     def matchback_candidate(existing_candidate_request, opts = {})
-      matchback_candidate_with_http_info(existing_candidate_request, opts)
-      nil
+      data, _status_code, _headers = matchback_candidate_with_http_info(existing_candidate_request, opts)
+      data
     end
 
     # Perform a matchback operation to retrieve a pre-populated TeacherTrainingAdviserSignUp for the candidate.
     # Attempts to matchback against a known candidate and returns a pre-populated TeacherTrainingAdviser sign up if a match is found.
     # @param existing_candidate_request [ExistingCandidateRequest] Candidate details to matchback.
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    # @return [Array<(TeacherTrainingAdviserSignUp, Integer, Hash)>] TeacherTrainingAdviserSignUp data, response status code and response headers
     def matchback_candidate_with_http_info(existing_candidate_request, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: TeacherTrainingAdviserApi.matchback_candidate ...'
@@ -139,7 +139,7 @@ module GetIntoTeachingApiClient
       post_body = opts[:debug_body] || @api_client.object_to_http_body(existing_candidate_request)
 
       # return_type
-      return_type = opts[:debug_return_type]
+      return_type = opts[:debug_return_type] || 'TeacherTrainingAdviserSignUp'
 
       # auth_names
       auth_names = opts[:debug_auth_names] || ['apiKey']

--- a/auto-generated-gem/spec/api/teacher_training_adviser_api_spec.rb
+++ b/auto-generated-gem/spec/api/teacher_training_adviser_api_spec.rb
@@ -50,7 +50,7 @@ describe 'TeacherTrainingAdviserApi' do
   # Attempts to matchback against a known candidate and returns a pre-populated TeacherTrainingAdviser sign up if a match is found.
   # @param existing_candidate_request Candidate details to matchback.
   # @param [Hash] opts the optional parameters
-  # @return [nil]
+  # @return [TeacherTrainingAdviserSignUp]
   describe 'matchback_candidate test' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
The swagger annotation for the return type was missing and so this didn't generate correctly.