### PR TITLE
Update faraday to 2.x

### DIFF
--- a/api-client/Gemfile.lock
+++ b/api-client/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../auto-generated-gem
   specs:
     get_into_teaching_api_client (3.7.0)
-      faraday (~> 1.0, >= 1.0.1)
+      faraday (~> 2.0, >= 2.0.0)
 
 PATH
   remote: .
@@ -12,7 +12,7 @@ PATH
       faraday
       faraday-encoding
       faraday-http-cache
-      faraday_middleware
+      faraday-retry
       faraday_middleware-circuit_breaker
       get_into_teaching_api_client
 
@@ -25,34 +25,48 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.2.2)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    connection_pool (2.5.3)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     diff-lcs (1.4.4)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-encoding (0.0.5)
       faraday
     faraday-http-cache (2.5.0)
       faraday (>= 0.8)
-    faraday-net_http (1.0.1)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
-    faraday_middleware-circuit_breaker (0.4.1)
-      faraday (>= 0.9, < 2.0)
-      stoplight (~> 2.1)
-    hashdiff (1.0.1)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
+    faraday_middleware-circuit_breaker (0.6.0)
+      faraday (>= 0.9, < 3.0)
+      stoplight (>= 2.1, < 4.0)
+    hashdiff (1.2.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    json (2.13.2)
+    logger (1.7.0)
     minitest (5.18.0)
-    multipart-post (2.1.1)
-    public_suffix (4.0.6)
+    net-http (0.6.0)
+      uri
+    public_suffix (6.0.2)
     rake (12.3.3)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.25.2)
+      connection_pool
+    redlock (1.3.2)
+      redis (>= 3.0.0, < 6.0)
+    rexml (3.4.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -66,13 +80,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    ruby2_keywords (0.0.4)
-    safe_yaml (1.0.5)
-    stoplight (2.2.1)
+    stoplight (3.0.2)
+      redlock (~> 1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webmock (3.9.1)
-      addressable (>= 2.3.6)
+    uri (1.0.3)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     zeitwerk (2.6.8)

--- a/api-client/api-client.gemspec
+++ b/api-client/api-client.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency("faraday")
   spec.add_dependency("faraday-encoding")
   spec.add_dependency("faraday-http-cache")
-  spec.add_dependency("faraday_middleware")
   spec.add_dependency("activesupport")
   spec.add_dependency("faraday_middleware-circuit_breaker")
+  spec.add_dependency("faraday-retry")
 
   spec.add_runtime_dependency("get_into_teaching_api_client")
 end

--- a/api-client/lib/api/client.rb
+++ b/api-client/lib/api/client.rb
@@ -1,5 +1,5 @@
 require "faraday"
-require "faraday_middleware"
+require 'faraday/retry'
 require "faraday/http_cache"
 require "faraday/encoding"
 require "active_support/cache"

--- a/api-client/lib/api/extensions/get_into_teaching_api_client/configuration.rb
+++ b/api-client/lib/api/extensions/get_into_teaching_api_client/configuration.rb
@@ -4,8 +4,7 @@ module Extensions
       RETRY_OPTIONS = {
         max: 2,
         methods: %i[get],
-        exceptions:
-          ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [::Faraday::ConnectionFailed],
+        exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed],
       }.freeze
       REQUEST_TIMEOUT = 10.seconds
 

--- a/auto-generated-gem/get_into_teaching_api_client.gemspec
+++ b/auto-generated-gem/get_into_teaching_api_client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 2.4"
 
-  s.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'faraday', '~> 2.0', '>= 2.0.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 

--- a/auto-generated-gem/lib/get_into_teaching_api_client/api_client.rb
+++ b/auto-generated-gem/lib/get_into_teaching_api_client/api_client.rb
@@ -16,6 +16,7 @@ require 'logger'
 require 'tempfile'
 require 'time'
 require 'faraday'
+require "ostruct"
 
 module GetIntoTeachingApiClient
   class ApiClient
@@ -56,7 +57,7 @@ module GetIntoTeachingApiClient
       }
 
       connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
-        conn.request(:basic_auth, config.username, config.password)
+        conn.request :authorization, :basic, config.username, config.password
         @config.configure_middleware(conn)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
           conn.request :multipart


### PR DESCRIPTION
Apps using this gem and have their own faraday or use other gems that use faraday, were struggling with version conflicts.

This gem uses an old version of faraday, 1.x. Whilst other libraries or apps use 2.x.

So we need to upgrade faraday, and in doing so we removed faraday-middleware as it's deprecated and according to the readme of the repository, a lot of the functionality has been incorporated by the faraday gem itself, in 2.x